### PR TITLE
Fix source archive and Git URLs

### DIFF
--- a/README
+++ b/README
@@ -22,10 +22,10 @@ Download
 ========
 
 Source archive of head revision:
-http://github.com/nocturnal/Helium/zipball/master
+http://github.com/HeliumProject/Helium/zipball/master
 
 Git URL (read only):
-git://github.com/nocturnal/Helium.git
+git://github.com/HeliumProject/Helium.git
 
 =============
 Prerequisites


### PR DESCRIPTION
Previous source archive and Git URLs were out-dated.
